### PR TITLE
Add create service and currency field

### DIFF
--- a/src/main/java/com/meplato/store2/MeResponse.java
+++ b/src/main/java/com/meplato/store2/MeResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Meplato GmbH, Switzerland.
+ * Copyright (c) 2013-present Meplato GmbH.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/com/meplato/store2/Merchant.java
+++ b/src/main/java/com/meplato/store2/Merchant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Meplato GmbH, Switzerland.
+ * Copyright (c) 2013-present Meplato GmbH.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/com/meplato/store2/Service.java
+++ b/src/main/java/com/meplato/store2/Service.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Meplato GmbH, Switzerland.
+ * Copyright (c) 2013-present Meplato GmbH.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,20 +14,22 @@
 // THIS FILE IS AUTO-GENERATED. DO NOT MODIFY!
 /**
  * Package store2 implements the Meplato Store API.
- *
- * @copyright 2014-2018 Meplato GmbH, Switzerland.
+ * 
+ * @copyright 2013-2020 Meplato GmbH.
  * @author Meplato API Team <support@meplato.com>
- * @version 2.1.5
- * @license Copyright (c) 2015-2018 Meplato GmbH, Switzerland. All rights reserved.
+ * @version 2.1.6
+ * @license Copyright (c) 2015-2020 Meplato GmbH. All rights reserved.
  * @see <a href="https://developer.meplato.com/store2/#terms">Terms of Service</a>
  * @see <a href="https://developer.meplato.com/store2/">External documentation</a>
  */
 package com.meplato.store2;
 
-import org.apache.commons.codec.binary.Base64;
-
 import java.util.HashMap;
 import java.util.Map;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.apache.commons.codec.binary.Base64;
 
 /**
  * Service is the entry point of the Meplato Store API.
@@ -37,11 +39,13 @@ public class Service {
     /** API title. */
     public static String TITLE = "Meplato Store API";
     /** API version. */
-    public static String VERSION = "2.1.5";
+    public static String VERSION = "2.1.6";
     /** User Agent. */
     public static String USER_AGENT = "meplato-java-client/2.0";
     /** Default base URL of the API endpoints. */
     public static String BASE_URL = "https://store.meplato.com/api/v2";
+    /** RFC3339 pattern for deserializing date/time from the API. */
+    public static String RFC3339 = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSXXX";
 
     /** Client to use for requests. */
     private final Client client;
@@ -60,6 +64,15 @@ public class Service {
     public Service(Client client) {
         this.client = client;
         this.baseURL = BASE_URL;
+    }
+
+    /**
+     * Returns the JSON serializer for this service.
+     *
+     * @return the JSON serializer.
+     */
+    public static Gson getSerializer() {
+        return new GsonBuilder().setDateFormat(RFC3339).create();
     }
 
     /**

--- a/src/main/java/com/meplato/store2/Service.java
+++ b/src/main/java/com/meplato/store2/Service.java
@@ -17,7 +17,7 @@
  * 
  * @copyright 2013-2020 Meplato GmbH.
  * @author Meplato API Team <support@meplato.com>
- * @version 2.1.6
+ * @version 2.1.7
  * @license Copyright (c) 2015-2020 Meplato GmbH. All rights reserved.
  * @see <a href="https://developer.meplato.com/store2/#terms">Terms of Service</a>
  * @see <a href="https://developer.meplato.com/store2/">External documentation</a>
@@ -39,7 +39,7 @@ public class Service {
     /** API title. */
     public static String TITLE = "Meplato Store API";
     /** API version. */
-    public static String VERSION = "2.1.6";
+    public static String VERSION = "2.1.7";
     /** User Agent. */
     public static String USER_AGENT = "meplato-java-client/2.0";
     /** Default base URL of the API endpoints. */

--- a/src/main/java/com/meplato/store2/User.java
+++ b/src/main/java/com/meplato/store2/User.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Meplato GmbH, Switzerland.
+ * Copyright (c) 2013-present Meplato GmbH.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/com/meplato/store2/catalogs/Catalog.java
+++ b/src/main/java/com/meplato/store2/catalogs/Catalog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Meplato GmbH, Switzerland.
+ * Copyright (c) 2013-present Meplato GmbH.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -113,6 +113,8 @@ public class Catalog {
     private boolean supportsOciSourcing;
     @SerializedName("supportsOciValidate")
     private boolean supportsOciValidate;
+    @SerializedName("target")
+    private String target;
     @SerializedName("type")
     private String type;
     @SerializedName("updated")
@@ -818,6 +820,22 @@ public class Catalog {
      */
     public void setSupportsOciValidate(boolean supportsOciValidate) {
         this.supportsOciValidate = supportsOciValidate;
+    }
+
+    /**
+     * Target represents the target system which can be either an empty string,
+     * "catscout" or "mall".
+     */
+    public String getTarget() {
+        return this.target;
+    }
+
+    /**
+     * Target represents the target system which can be either an empty string,
+     * "catscout" or "mall".
+     */
+    public void setTarget(String target) {
+        this.target = target;
     }
 
     /**

--- a/src/main/java/com/meplato/store2/catalogs/CreateCatalog.java
+++ b/src/main/java/com/meplato/store2/catalogs/CreateCatalog.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright (c) 2013-present Meplato GmbH.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.meplato.store2.catalogs;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * CreateCatalog holds the properties of a new catalog.
+ */
+public class CreateCatalog {
+    @SerializedName("country")
+    private String country;
+    @SerializedName("currency")
+    private String currency;
+    @SerializedName("description")
+    private String description;
+    @SerializedName("language")
+    private String language;
+    @SerializedName("merchantId")
+    private long merchantId;
+    @SerializedName("name")
+    private String name;
+    @SerializedName("projectId")
+    private long projectId;
+    @SerializedName("projectMpcc")
+    private String projectMpcc;
+    @SerializedName("sageContract")
+    private String sageContract;
+    @SerializedName("sageNumber")
+    private String sageNumber;
+    @SerializedName("target")
+    private String target;
+    @SerializedName("validFrom")
+    private String validFrom;
+    @SerializedName("validUntil")
+    private String validUntil;
+
+    /**
+     * Create new instance of CreateCatalog.
+     */
+    public CreateCatalog() {
+    }
+
+    /**
+     * Country is the ISO-3166 alpha-2 code for the country that the catalog is
+     * destined for (e.g. DE or US).
+     */
+    public String getCountry() {
+        return this.country;
+    }
+
+    /**
+     * Country is the ISO-3166 alpha-2 code for the country that the catalog is
+     * destined for (e.g. DE or US).
+     */
+    public void setCountry(String country) {
+        this.country = country;
+    }
+
+    /**
+     * Currency is the ISO-4217 currency code that is used for all products in the
+     * catalog (e.g. EUR or USD).
+     */
+    public String getCurrency() {
+        return this.currency;
+    }
+
+    /**
+     * Currency is the ISO-4217 currency code that is used for all products in the
+     * catalog (e.g. EUR or USD).
+     */
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    /**
+     * Description of the catalog.
+     */
+    public String getDescription() {
+        return this.description;
+    }
+
+    /**
+     * Description of the catalog.
+     */
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+     * Language is the IETF language tag of the language of all products in the
+     * catalog (e.g. de or pt-BR).
+     */
+    public String getLanguage() {
+        return this.language;
+    }
+
+    /**
+     * Language is the IETF language tag of the language of all products in the
+     * catalog (e.g. de or pt-BR).
+     */
+    public void setLanguage(String language) {
+        this.language = language;
+    }
+
+    /**
+     * ID of the merchant.
+     */
+    public long getMerchantId() {
+        return this.merchantId;
+    }
+
+    /**
+     * ID of the merchant.
+     */
+    public void setMerchantId(long merchantId) {
+        this.merchantId = merchantId;
+    }
+
+    /**
+     * Name of the catalog.
+     */
+    public String getName() {
+        return this.name;
+    }
+
+    /**
+     * Name of the catalog.
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * ID of the project.
+     */
+    public long getProjectId() {
+        return this.projectId;
+    }
+
+    /**
+     * ID of the project.
+     */
+    public void setProjectId(long projectId) {
+        this.projectId = projectId;
+    }
+
+    /**
+     * MPCC of the project.
+     */
+    public String getProjectMpcc() {
+        return this.projectMpcc;
+    }
+
+    /**
+     * MPCC of the project.
+     */
+    public void setProjectMpcc(String projectMpcc) {
+        this.projectMpcc = projectMpcc;
+    }
+
+    /**
+     * SageContract represents the internal identifier at Meplato for the contract
+     * of this catalog.
+     */
+    public String getSageContract() {
+        return this.sageContract;
+    }
+
+    /**
+     * SageContract represents the internal identifier at Meplato for the contract
+     * of this catalog.
+     */
+    public void setSageContract(String sageContract) {
+        this.sageContract = sageContract;
+    }
+
+    /**
+     * SageNumber represents the internal identifier at Meplato for the merchant of
+     * this catalog.
+     */
+    public String getSageNumber() {
+        return this.sageNumber;
+    }
+
+    /**
+     * SageNumber represents the internal identifier at Meplato for the merchant of
+     * this catalog.
+     */
+    public void setSageNumber(String sageNumber) {
+        this.sageNumber = sageNumber;
+    }
+
+    /**
+     * Target represents the target system which can be either an empty string,
+     * "catscout" or "mall".
+     */
+    public String getTarget() {
+        return this.target;
+    }
+
+    /**
+     * Target represents the target system which can be either an empty string,
+     * "catscout" or "mall".
+     */
+    public void setTarget(String target) {
+        this.target = target;
+    }
+
+    /**
+     * ValidFrom is the date the catalog becomes effective (YYYY-MM-DD).
+     */
+    public String getValidFrom() {
+        return this.validFrom;
+    }
+
+    /**
+     * ValidFrom is the date the catalog becomes effective (YYYY-MM-DD).
+     */
+    public void setValidFrom(String validFrom) {
+        this.validFrom = validFrom;
+    }
+
+    /**
+     * ValidUntil is the date the catalog expires (YYYY-MM-DD).
+     */
+    public String getValidUntil() {
+        return this.validUntil;
+    }
+
+    /**
+     * ValidUntil is the date the catalog expires (YYYY-MM-DD).
+     */
+    public void setValidUntil(String validUntil) {
+        this.validUntil = validUntil;
+    }
+}
+

--- a/src/main/java/com/meplato/store2/catalogs/CustField.java
+++ b/src/main/java/com/meplato/store2/catalogs/CustField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Meplato GmbH, Switzerland.
+ * Copyright (c) 2013-present Meplato GmbH.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/com/meplato/store2/catalogs/KPISummary.java
+++ b/src/main/java/com/meplato/store2/catalogs/KPISummary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Meplato GmbH, Switzerland.
+ * Copyright (c) 2013-present Meplato GmbH.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/com/meplato/store2/catalogs/Project.java
+++ b/src/main/java/com/meplato/store2/catalogs/Project.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Meplato GmbH, Switzerland.
+ * Copyright (c) 2013-present Meplato GmbH.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/com/meplato/store2/catalogs/PublishResponse.java
+++ b/src/main/java/com/meplato/store2/catalogs/PublishResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Meplato GmbH, Switzerland.
+ * Copyright (c) 2013-present Meplato GmbH.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/com/meplato/store2/catalogs/PublishStatusResponse.java
+++ b/src/main/java/com/meplato/store2/catalogs/PublishStatusResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Meplato GmbH, Switzerland.
+ * Copyright (c) 2013-present Meplato GmbH.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/com/meplato/store2/catalogs/PurgeResponse.java
+++ b/src/main/java/com/meplato/store2/catalogs/PurgeResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Meplato GmbH, Switzerland.
+ * Copyright (c) 2013-present Meplato GmbH.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/com/meplato/store2/catalogs/SearchResponse.java
+++ b/src/main/java/com/meplato/store2/catalogs/SearchResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Meplato GmbH, Switzerland.
+ * Copyright (c) 2013-present Meplato GmbH.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/com/meplato/store2/catalogs/Service.java
+++ b/src/main/java/com/meplato/store2/catalogs/Service.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Meplato GmbH, Switzerland.
+ * Copyright (c) 2013-present Meplato GmbH.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,61 +14,48 @@
 // THIS FILE IS AUTO-GENERATED. DO NOT MODIFY!
 /**
  * Package catalogs implements the Meplato Store API.
- *
- * @copyright 2014-2018 Meplato GmbH, Switzerland.
+ * 
+ * @copyright 2013-2020 Meplato GmbH.
  * @author Meplato API Team <support@meplato.com>
- * @version 2.1.5
- * @license Copyright (c) 2015-2018 Meplato GmbH, Switzerland. All rights reserved.
+ * @version 2.1.6
+ * @license Copyright (c) 2015-2020 Meplato GmbH. All rights reserved.
  * @see <a href="https://developer.meplato.com/store2/#terms">Terms of Service</a>
  * @see <a href="https://developer.meplato.com/store2/">External documentation</a>
  */
 package com.meplato.store2.catalogs;
 
-import com.meplato.store2.Client;
-import com.meplato.store2.Response;
-import com.meplato.store2.ServiceException;
-import org.apache.commons.codec.binary.Base64;
-
 import java.util.HashMap;
 import java.util.Map;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.apache.commons.codec.binary.Base64;
+
+import com.meplato.store2.*;
 
 /**
  * Service is the entry point of the Meplato Store API.
  */
 
 public class Service {
-    /**
-     * API title.
-     */
+    /** API title. */
     public static String TITLE = "Meplato Store API";
-    /**
-     * API version.
-     */
-    public static String VERSION = "2.1.5";
-    /**
-     * User Agent.
-     */
+    /** API version. */
+    public static String VERSION = "2.1.6";
+    /** User Agent. */
     public static String USER_AGENT = "meplato-java-client/2.0";
-    /**
-     * Default base URL of the API endpoints.
-     */
+    /** Default base URL of the API endpoints. */
     public static String BASE_URL = "https://store.meplato.com/api/v2";
+    /** RFC3339 pattern for deserializing date/time from the API. */
+    public static String RFC3339 = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSXXX";
 
-    /**
-     * Client to use for requests.
-     */
+    /** Client to use for requests. */
     private final Client client;
-    /**
-     * Base URL for the API endpoints.
-     */
+    /** Base URL for the API endpoints. */
     private String baseURL;
-    /**
-     * User name for authentication.
-     */
+    /** User name for authentication. */
     private String user;
-    /**
-     * Password for authentication.
-     */
+    /** Password for authentication. */
     private String password;
 
     /**
@@ -79,6 +66,15 @@ public class Service {
     public Service(Client client) {
         this.client = client;
         this.baseURL = BASE_URL;
+    }
+
+    /**
+     * Returns the JSON serializer for this service.
+     *
+     * @return the JSON serializer.
+     */
+    public static Gson getSerializer() {
+        return new GsonBuilder().setDateFormat(RFC3339).create();
     }
 
     /**
@@ -168,6 +164,15 @@ public class Service {
     }
 
     /**
+     * Returns the {@link CreateService}.
+     *
+     * @return the {@link CreateService}.
+     */
+    public CreateService create() {
+        return new CreateService(this);
+    }
+
+    /**
      * Returns the {@link GetService}.
      *
      * @return the {@link GetService}.
@@ -210,6 +215,57 @@ public class Service {
      */
     public SearchService search() {
         return new SearchService(this);
+    }
+
+    /**
+     * Create a new catalog (admin only).
+     */
+    public static class CreateService {
+        private final Service service;
+        private final Map<String, Object> params = new HashMap<String, Object>();
+        private final Map<String, String> headers = new HashMap<String, String>();
+        private CreateCatalog catalog;
+
+        /**
+         * Creates a new instance of CreateService.
+         */
+        public CreateService(Service service) {
+            this.service = service;
+        }
+
+        /**
+         * Catalog properties of the new catalog.
+         */
+        public CreateService catalog(CreateCatalog catalog) {
+            this.catalog = catalog;
+            return this;
+        }
+
+        /**
+         * Execute the operation.
+         */
+        public Catalog execute() throws ServiceException {
+            // Make a copy of the parameters and add the path parameters to it
+            Map<String, Object> params = new HashMap<String, Object>();
+            params.putAll(this.params);
+
+            // Make a copy of the header parameters and set common headers, like the UA
+            Map<String, String> headers = new HashMap<String, String>();
+            headers.putAll(this.headers);
+
+            String authorization = service.getAuthorizationHeader();
+            if (authorization != null && !authorization.isEmpty()) {
+                headers.put("Authorization", authorization);
+            }
+
+            String uriTemplate = service.getBaseURL() + "/catalogs";
+            Response response = service.getClient().execute("POST", uriTemplate, params, headers, this.catalog);
+            if (response != null && response.getStatusCode() >= 200 && response.getStatusCode() < 300) {
+                return response.getBodyJSON(Catalog.class);
+            }
+
+            throw ServiceException.fromResponse(response);
+        }
     }
 
     /**

--- a/src/main/java/com/meplato/store2/catalogs/Service.java
+++ b/src/main/java/com/meplato/store2/catalogs/Service.java
@@ -17,7 +17,7 @@
  * 
  * @copyright 2013-2020 Meplato GmbH.
  * @author Meplato API Team <support@meplato.com>
- * @version 2.1.6
+ * @version 2.1.7
  * @license Copyright (c) 2015-2020 Meplato GmbH. All rights reserved.
  * @see <a href="https://developer.meplato.com/store2/#terms">Terms of Service</a>
  * @see <a href="https://developer.meplato.com/store2/">External documentation</a>
@@ -41,7 +41,7 @@ public class Service {
     /** API title. */
     public static String TITLE = "Meplato Store API";
     /** API version. */
-    public static String VERSION = "2.1.6";
+    public static String VERSION = "2.1.7";
     /** User Agent. */
     public static String USER_AGENT = "meplato-java-client/2.0";
     /** Default base URL of the API endpoints. */

--- a/src/main/java/com/meplato/store2/jobs/Job.java
+++ b/src/main/java/com/meplato/store2/jobs/Job.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Meplato GmbH, Switzerland.
+ * Copyright (c) 2013-present Meplato GmbH.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/com/meplato/store2/jobs/SearchResponse.java
+++ b/src/main/java/com/meplato/store2/jobs/SearchResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Meplato GmbH, Switzerland.
+ * Copyright (c) 2013-present Meplato GmbH.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/com/meplato/store2/jobs/Service.java
+++ b/src/main/java/com/meplato/store2/jobs/Service.java
@@ -17,7 +17,7 @@
  * 
  * @copyright 2013-2020 Meplato GmbH.
  * @author Meplato API Team <support@meplato.com>
- * @version 2.1.6
+ * @version 2.1.7
  * @license Copyright (c) 2015-2020 Meplato GmbH. All rights reserved.
  * @see <a href="https://developer.meplato.com/store2/#terms">Terms of Service</a>
  * @see <a href="https://developer.meplato.com/store2/">External documentation</a>
@@ -41,7 +41,7 @@ public class Service {
     /** API title. */
     public static String TITLE = "Meplato Store API";
     /** API version. */
-    public static String VERSION = "2.1.6";
+    public static String VERSION = "2.1.7";
     /** User Agent. */
     public static String USER_AGENT = "meplato-java-client/2.0";
     /** Default base URL of the API endpoints. */

--- a/src/main/java/com/meplato/store2/jobs/Service.java
+++ b/src/main/java/com/meplato/store2/jobs/Service.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Meplato GmbH, Switzerland.
+ * Copyright (c) 2013-present Meplato GmbH.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,23 +14,24 @@
 // THIS FILE IS AUTO-GENERATED. DO NOT MODIFY!
 /**
  * Package jobs implements the Meplato Store API.
- *
- * @copyright 2014-2018 Meplato GmbH, Switzerland.
+ * 
+ * @copyright 2013-2020 Meplato GmbH.
  * @author Meplato API Team <support@meplato.com>
- * @version 2.1.5
- * @license Copyright (c) 2015-2018 Meplato GmbH, Switzerland. All rights reserved.
+ * @version 2.1.6
+ * @license Copyright (c) 2015-2020 Meplato GmbH. All rights reserved.
  * @see <a href="https://developer.meplato.com/store2/#terms">Terms of Service</a>
  * @see <a href="https://developer.meplato.com/store2/">External documentation</a>
  */
 package com.meplato.store2.jobs;
 
-import com.meplato.store2.Client;
-import com.meplato.store2.Response;
-import com.meplato.store2.ServiceException;
-import org.apache.commons.codec.binary.Base64;
-
 import java.util.HashMap;
 import java.util.Map;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.apache.commons.codec.binary.Base64;
+
+import com.meplato.store2.*;
 
 /**
  * Service is the entry point of the Meplato Store API.
@@ -40,11 +41,13 @@ public class Service {
     /** API title. */
     public static String TITLE = "Meplato Store API";
     /** API version. */
-    public static String VERSION = "2.1.5";
+    public static String VERSION = "2.1.6";
     /** User Agent. */
     public static String USER_AGENT = "meplato-java-client/2.0";
     /** Default base URL of the API endpoints. */
     public static String BASE_URL = "https://store.meplato.com/api/v2";
+    /** RFC3339 pattern for deserializing date/time from the API. */
+    public static String RFC3339 = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSXXX";
 
     /** Client to use for requests. */
     private final Client client;
@@ -63,6 +66,15 @@ public class Service {
     public Service(Client client) {
         this.client = client;
         this.baseURL = BASE_URL;
+    }
+
+    /**
+     * Returns the JSON serializer for this service.
+     *
+     * @return the JSON serializer.
+     */
+    public static Gson getSerializer() {
+        return new GsonBuilder().setDateFormat(RFC3339).create();
     }
 
     /**

--- a/src/main/java/com/meplato/store2/products/Availability.java
+++ b/src/main/java/com/meplato/store2/products/Availability.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Meplato GmbH, Switzerland.
+ * Copyright (c) 2013-present Meplato GmbH.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/com/meplato/store2/products/Blob.java
+++ b/src/main/java/com/meplato/store2/products/Blob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Meplato GmbH, Switzerland.
+ * Copyright (c) 2013-present Meplato GmbH.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/com/meplato/store2/products/Condition.java
+++ b/src/main/java/com/meplato/store2/products/Condition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Meplato GmbH, Switzerland.
+ * Copyright (c) 2013-present Meplato GmbH.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/com/meplato/store2/products/CreateProduct.java
+++ b/src/main/java/com/meplato/store2/products/CreateProduct.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Meplato GmbH, Switzerland.
+ * Copyright (c) 2013-present Meplato GmbH.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -51,6 +51,8 @@ public class CreateProduct {
     private String contentUnit;
     @SerializedName("cuPerOu")
     private Double cuPerOu;
+    @SerializedName("currency")
+    private String currency;
     @SerializedName("custField1")
     private String custField1;
     @SerializedName("custField2")
@@ -486,6 +488,24 @@ public class CreateProduct {
      */
     public void setCuPerOu(Double cuPerOu) {
         this.cuPerOu = cuPerOu;
+    }
+
+    /**
+     * Currency is the ISO currency code for the prices, e.g. EUR or GBP. If you
+     * pass an empty currency code, it will be initialized with the catalog's
+     * currency. 
+     */
+    public String getCurrency() {
+        return this.currency;
+    }
+
+    /**
+     * Currency is the ISO currency code for the prices, e.g. EUR or GBP. If you
+     * pass an empty currency code, it will be initialized with the catalog's
+     * currency. 
+     */
+    public void setCurrency(String currency) {
+        this.currency = currency;
     }
 
     /**

--- a/src/main/java/com/meplato/store2/products/CreateProductResponse.java
+++ b/src/main/java/com/meplato/store2/products/CreateProductResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Meplato GmbH, Switzerland.
+ * Copyright (c) 2013-present Meplato GmbH.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/com/meplato/store2/products/CustField.java
+++ b/src/main/java/com/meplato/store2/products/CustField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Meplato GmbH, Switzerland.
+ * Copyright (c) 2013-present Meplato GmbH.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/com/meplato/store2/products/Eclass.java
+++ b/src/main/java/com/meplato/store2/products/Eclass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Meplato GmbH, Switzerland.
+ * Copyright (c) 2013-present Meplato GmbH.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/com/meplato/store2/products/Feature.java
+++ b/src/main/java/com/meplato/store2/products/Feature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Meplato GmbH, Switzerland.
+ * Copyright (c) 2013-present Meplato GmbH.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/com/meplato/store2/products/Hazmat.java
+++ b/src/main/java/com/meplato/store2/products/Hazmat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Meplato GmbH, Switzerland.
+ * Copyright (c) 2013-present Meplato GmbH.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/com/meplato/store2/products/Intrastat.java
+++ b/src/main/java/com/meplato/store2/products/Intrastat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Meplato GmbH, Switzerland.
+ * Copyright (c) 2013-present Meplato GmbH.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/com/meplato/store2/products/Product.java
+++ b/src/main/java/com/meplato/store2/products/Product.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Meplato GmbH, Switzerland.
+ * Copyright (c) 2013-present Meplato GmbH.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,9 +13,9 @@
  */
 package com.meplato.store2.products;
 
-import com.google.gson.annotations.SerializedName;
-
 import java.util.Date;
+
+import com.google.gson.annotations.SerializedName;
 
 /**
  * Product is a good or service in a catalog.
@@ -535,14 +535,18 @@ public class Product {
     }
 
     /**
-     * Currency is the ISO currency code for the prices, e.g. EUR or GBP.
+     * Currency is the ISO currency code for the prices, e.g. EUR or GBP. If you
+     * pass an empty currency code, it will be initialized with the catalog's
+     * currency.
      */
     public String getCurrency() {
         return this.currency;
     }
 
     /**
-     * Currency is the ISO currency code for the prices, e.g. EUR or GBP.
+     * Currency is the ISO currency code for the prices, e.g. EUR or GBP. If you
+     * pass an empty currency code, it will be initialized with the catalog's
+     * currency.
      */
     public void setCurrency(String currency) {
         this.currency = currency;

--- a/src/main/java/com/meplato/store2/products/Reference.java
+++ b/src/main/java/com/meplato/store2/products/Reference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Meplato GmbH, Switzerland.
+ * Copyright (c) 2013-present Meplato GmbH.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/com/meplato/store2/products/ReplaceProduct.java
+++ b/src/main/java/com/meplato/store2/products/ReplaceProduct.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Meplato GmbH, Switzerland.
+ * Copyright (c) 2013-present Meplato GmbH.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -51,6 +51,8 @@ public class ReplaceProduct {
     private String contentUnit;
     @SerializedName("cuPerOu")
     private Double cuPerOu;
+    @SerializedName("currency")
+    private String currency;
     @SerializedName("custField1")
     private String custField1;
     @SerializedName("custField2")
@@ -486,6 +488,24 @@ public class ReplaceProduct {
      */
     public void setCuPerOu(Double cuPerOu) {
         this.cuPerOu = cuPerOu;
+    }
+
+    /**
+     * Currency is the ISO currency code for the prices, e.g. EUR or GBP. If you
+     * pass an empty currency code, it will be initialized with the catalog's
+     * currency. 
+     */
+    public String getCurrency() {
+        return this.currency;
+    }
+
+    /**
+     * Currency is the ISO currency code for the prices, e.g. EUR or GBP. If you
+     * pass an empty currency code, it will be initialized with the catalog's
+     * currency. 
+     */
+    public void setCurrency(String currency) {
+        this.currency = currency;
     }
 
     /**

--- a/src/main/java/com/meplato/store2/products/ReplaceProductResponse.java
+++ b/src/main/java/com/meplato/store2/products/ReplaceProductResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Meplato GmbH, Switzerland.
+ * Copyright (c) 2013-present Meplato GmbH.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/com/meplato/store2/products/ScalePrice.java
+++ b/src/main/java/com/meplato/store2/products/ScalePrice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Meplato GmbH, Switzerland.
+ * Copyright (c) 2013-present Meplato GmbH.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/com/meplato/store2/products/ScrollResponse.java
+++ b/src/main/java/com/meplato/store2/products/ScrollResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Meplato GmbH, Switzerland.
+ * Copyright (c) 2013-present Meplato GmbH.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/com/meplato/store2/products/SearchResponse.java
+++ b/src/main/java/com/meplato/store2/products/SearchResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Meplato GmbH, Switzerland.
+ * Copyright (c) 2013-present Meplato GmbH.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/com/meplato/store2/products/Service.java
+++ b/src/main/java/com/meplato/store2/products/Service.java
@@ -17,7 +17,7 @@
  *
  * @copyright 2013-2020 Meplato GmbH.
  * @author Meplato API Team <support@meplato.com>
- * @version 2.1.6
+ * @version 2.1.7
  * @license Copyright (c) 2015-2020 Meplato GmbH. All rights reserved.
  * @see <a href="https://developer.meplato.com/store2/#terms">Terms of Service</a>
  * @see <a href="https://developer.meplato.com/store2/">External documentation</a>
@@ -41,7 +41,7 @@ public class Service {
     /** API title. */
     public static String TITLE = "Meplato Store API";
     /** API version. */
-    public static String VERSION = "2.1.6";
+    public static String VERSION = "2.1.7";
     /** User Agent. */
     public static String USER_AGENT = "meplato-java-client/2.0";
     /** Default base URL of the API endpoints. */

--- a/src/main/java/com/meplato/store2/products/Service.java
+++ b/src/main/java/com/meplato/store2/products/Service.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Meplato GmbH, Switzerland.
+ * Copyright (c) 2013-present Meplato GmbH.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,22 +15,23 @@
 /**
  * Package products implements the Meplato Store API.
  *
- * @copyright 2014-2018 Meplato GmbH, Switzerland.
+ * @copyright 2013-2020 Meplato GmbH.
  * @author Meplato API Team <support@meplato.com>
- * @version 2.1.5
- * @license Copyright (c) 2015-2018 Meplato GmbH, Switzerland. All rights reserved.
+ * @version 2.1.6
+ * @license Copyright (c) 2015-2020 Meplato GmbH. All rights reserved.
  * @see <a href="https://developer.meplato.com/store2/#terms">Terms of Service</a>
  * @see <a href="https://developer.meplato.com/store2/">External documentation</a>
  */
 package com.meplato.store2.products;
 
-import com.meplato.store2.Client;
-import com.meplato.store2.Response;
-import com.meplato.store2.ServiceException;
-import org.apache.commons.codec.binary.Base64;
-
 import java.util.HashMap;
 import java.util.Map;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.apache.commons.codec.binary.Base64;
+
+import com.meplato.store2.*;
 
 /**
  * Service is the entry point of the Meplato Store API.
@@ -40,11 +41,13 @@ public class Service {
     /** API title. */
     public static String TITLE = "Meplato Store API";
     /** API version. */
-    public static String VERSION = "2.1.5";
+    public static String VERSION = "2.1.6";
     /** User Agent. */
     public static String USER_AGENT = "meplato-java-client/2.0";
     /** Default base URL of the API endpoints. */
     public static String BASE_URL = "https://store.meplato.com/api/v2";
+    /** RFC3339 pattern for deserializing date/time from the API. */
+    public static String RFC3339 = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSXXX";
 
     /** Client to use for requests. */
     private final Client client;
@@ -63,6 +66,15 @@ public class Service {
     public Service(Client client) {
         this.client = client;
         this.baseURL = BASE_URL;
+    }
+
+    /**
+     * Returns the JSON serializer for this service.
+     *
+     * @return the JSON serializer.
+     */
+    public static Gson getSerializer() {
+        return new GsonBuilder().setDateFormat(RFC3339).create();
     }
 
     /**

--- a/src/main/java/com/meplato/store2/products/Unspsc.java
+++ b/src/main/java/com/meplato/store2/products/Unspsc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Meplato GmbH, Switzerland.
+ * Copyright (c) 2013-present Meplato GmbH.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/com/meplato/store2/products/UpdateProduct.java
+++ b/src/main/java/com/meplato/store2/products/UpdateProduct.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Meplato GmbH, Switzerland.
+ * Copyright (c) 2013-present Meplato GmbH.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -53,6 +53,8 @@ public class UpdateProduct {
     private Optional<String> contentUnit;
     @SerializedName("cuPerOu")
     private Optional<Double> cuPerOu;
+    @SerializedName("currency")
+    private Optional<String> currency;
     @SerializedName("custField1")
     private Optional<String> custField1;
     @SerializedName("custField2")
@@ -413,6 +415,25 @@ public class UpdateProduct {
     public Optional<Double> getConversionDenumerator() {
         return this.conversionDenumerator;
     }
+
+    /**
+     * Currency is the ISO currency code for the prices, e.g. EUR or GBP. If you
+     * pass an empty currency code, it will be initialized with the catalog's
+     * currency.
+     */
+    public Optional<String> getCurrency() {
+        return this.currency;
+    }
+
+    /**
+     * Currency is the ISO currency code for the prices, e.g. EUR or GBP. If you
+     * pass an empty currency code, it will be initialized with the catalog's
+     * currency.
+     */
+    public void setCurrency(Optional<String> currency) {
+        this.currency = currency;
+    }
+
 
     /**
      * ConversionDenumerator is the denumerator for calculating price quantities.

--- a/src/main/java/com/meplato/store2/products/UpdateProductResponse.java
+++ b/src/main/java/com/meplato/store2/products/UpdateProductResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Meplato GmbH, Switzerland.
+ * Copyright (c) 2013-present Meplato GmbH.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/main/java/com/meplato/store2/products/UpsertProduct.java
+++ b/src/main/java/com/meplato/store2/products/UpsertProduct.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Meplato GmbH, Switzerland.
+ * Copyright (c) 2013-present Meplato GmbH.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -51,6 +51,8 @@ public class UpsertProduct {
     private String contentUnit;
     @SerializedName("cuPerOu")
     private Double cuPerOu;
+    @SerializedName("currency")
+    private String currency;
     @SerializedName("custField1")
     private String custField1;
     @SerializedName("custField2")
@@ -486,6 +488,24 @@ public class UpsertProduct {
      */
     public void setCuPerOu(Double cuPerOu) {
         this.cuPerOu = cuPerOu;
+    }
+
+    /**
+     * Currency is the ISO currency code for the prices, e.g. EUR or GBP. If you
+     * pass an empty currency code, it will be initialized with the catalog's
+     * currency. 
+     */
+    public String getCurrency() {
+        return this.currency;
+    }
+
+    /**
+     * Currency is the ISO currency code for the prices, e.g. EUR or GBP. If you
+     * pass an empty currency code, it will be initialized with the catalog's
+     * currency. 
+     */
+    public void setCurrency(String currency) {
+        this.currency = currency;
     }
 
     /**

--- a/src/main/java/com/meplato/store2/products/UpsertProductResponse.java
+++ b/src/main/java/com/meplato/store2/products/UpsertProductResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Meplato GmbH, Switzerland.
+ * Copyright (c) 2013-present Meplato GmbH.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/src/test/java/com/meplato/store2/catalogs/CreateTest.java
+++ b/src/test/java/com/meplato/store2/catalogs/CreateTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2013-present Meplato GmbH.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.meplato.store2.catalogs;
+
+import com.meplato.store2.ServiceException;
+import com.meplato.store2.products.CreateProduct;
+import com.meplato.store2.products.CreateProductResponse;
+import org.apache.http.HttpException;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests creating a catalog
+ */
+public class CreateTest extends BaseTest {
+
+    @Test
+    public void testCreateCatalog() throws ServiceException, IOException, HttpException {
+        this.mockResponseFromFile("catalogs.create.success");
+
+        Service service = getCatalogsService();
+        assertNotNull(service);
+
+        CreateCatalog create = new CreateCatalog();
+        create.setMerchantId(1);
+        create.setName("test");
+        create.setProjectMpcc("meplato");
+        create.setValidFrom(null);
+        create.setValidUntil(null);
+        create.setCountry("DE");
+        create.setCurrency("EUR");
+        create.setLanguage("de");
+        create.setTarget("mall");
+        create.setSageNumber("");
+        create.setSageContract("");
+
+        Catalog catalog = service.create().catalog(create).execute();
+        assertNotNull(catalog);
+        assertNotNull(catalog.getSelfLink());
+        assertNotEquals("", catalog.getSelfLink());
+        assertEquals("store#catalog", catalog.getKind());
+    }
+}

--- a/src/test/resources/com/meplato/store2/catalogs/catalogs.create.success
+++ b/src/test/resources/com/meplato/store2/catalogs/catalogs.create.success
@@ -1,0 +1,11 @@
+HTTP/1.1 201 Created
+Content-Type: application/json; charset=utf-8
+P3p: CP="This is not a P3P policy!"
+Vary: Cookie
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Ua-Compatible: IE=edge
+X-Xss-Protection: 1; mode=block
+Date: Wed, 01 Apr 2015 13:53:54 GMT
+
+{"kind":"store#catalog","selfLink":"https://store3.go/api/v2/catalogs/48F31F33AD","id":81,"type":"corporate","merchantId":1,"merchantMpcc":"meplato","merchantMpsc":"meplato-sc","merchantName":"Meplato GmbH","projectId":1,"projectMpcc":"meplato","projectMpbc":"meplato","projectName":"Meplato","project":{"id":1,"type":"corporate","mpcc":"meplato","mpbc":"meplato","name":"Meplato","profile":{"nameExists":{"policy":1},"categoriesExists":{"policy":1},"eclassesValid":{"policy":0,"version":"5.1"},"orderUnitValues":{"policy":0},"contentUnitValues":{"policy":0}},"customization":{"hooks":[{"kind":"publish_initial","via":"smtp","target":"oe+dev-initial-publish@meplato.de"}]},"script":"","visible":true,"country":"DE","language":"de","locale":"de_DE","timeZone":"Europe/Berlin","currency":"EUR","ou":"PCE","catalogPriceInitial":0,"catalogPriceRecurring":0,"catalogPriceCurrency":"EUR","catalogPriceInterval":"yearly","target":"mall","companyGroup":"","created":"2017-10-09T14:29:35Z","updated":"2020-01-02T08:47:32Z"},"slug":"test2","name":"test2","pin":"48F31F33AD","validFrom":"2020-03-13","validUntil":"2099-12-31","currency":"EUR","country":"DE","language":"de","state":"idle","created":"2020-03-13T15:39:52.004116159Z","updated":"2020-03-13T15:39:52.004116159Z","lockedForDownload":false,"supportsOciDetail":false,"supportsOciDetailadd":false,"supportsOciValidate":false,"supportsOciSourcing":false,"supportsOciBackgroundsearch":false,"supportsOciQuantitycheck":false,"supportsOciDownloadjson":false,"keepOriginalBlobs":false,"target":"","showImportFailure":false}


### PR DESCRIPTION
The Api had several changes - `Create` catalog, removal of `Debitor`. The client was also missing `currency` attribute in products.

This PR updates the client with the latest API specification (2.1.7)

**Note**: This client is out of sync with the code generator. Probably by a manual update to the code base (Optional fields for `UpdateProduct` are not generated as well). A follow up issue for the java code generator is probably needed to align the code base. 

Close #9