### PR TITLE
Enable differential downloads

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 			<dependency>
 				<groupId>com.damnhandy</groupId>
 				<artifactId>handy-uri-templates</artifactId>
-				<version>2.1.7</version>
+				<version>2.1.8</version>
 			</dependency>
 			<dependency>
 				<groupId>joda-time</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
 			<dependency>
 				<groupId>joda-time</groupId>
 				<artifactId>joda-time</artifactId>
-				<version>2.10</version>
+				<version>2.10.2</version>
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.jetty</groupId>

--- a/src/main/java/com/meplato/store2/Service.java
+++ b/src/main/java/com/meplato/store2/Service.java
@@ -17,7 +17,7 @@
  * 
  * @copyright 2013-2020 Meplato GmbH.
  * @author Meplato API Team <support@meplato.com>
- * @version 2.1.7
+ * @version 2.1.8
  * @license Copyright (c) 2015-2020 Meplato GmbH. All rights reserved.
  * @see <a href="https://developer.meplato.com/store2/#terms">Terms of Service</a>
  * @see <a href="https://developer.meplato.com/store2/">External documentation</a>
@@ -39,7 +39,7 @@ public class Service {
     /** API title. */
     public static String TITLE = "Meplato Store API";
     /** API version. */
-    public static String VERSION = "2.1.7";
+    public static String VERSION = "2.1.8";
     /** User Agent. */
     public static String USER_AGENT = "meplato-java-client/2.0";
     /** Default base URL of the API endpoints. */

--- a/src/main/java/com/meplato/store2/catalogs/Service.java
+++ b/src/main/java/com/meplato/store2/catalogs/Service.java
@@ -17,7 +17,7 @@
  * 
  * @copyright 2013-2020 Meplato GmbH.
  * @author Meplato API Team <support@meplato.com>
- * @version 2.1.7
+ * @version 2.1.8
  * @license Copyright (c) 2015-2020 Meplato GmbH. All rights reserved.
  * @see <a href="https://developer.meplato.com/store2/#terms">Terms of Service</a>
  * @see <a href="https://developer.meplato.com/store2/">External documentation</a>
@@ -41,7 +41,7 @@ public class Service {
     /** API title. */
     public static String TITLE = "Meplato Store API";
     /** API version. */
-    public static String VERSION = "2.1.7";
+    public static String VERSION = "2.1.8";
     /** User Agent. */
     public static String USER_AGENT = "meplato-java-client/2.0";
     /** Default base URL of the API endpoints. */

--- a/src/main/java/com/meplato/store2/jobs/Service.java
+++ b/src/main/java/com/meplato/store2/jobs/Service.java
@@ -17,7 +17,7 @@
  * 
  * @copyright 2013-2020 Meplato GmbH.
  * @author Meplato API Team <support@meplato.com>
- * @version 2.1.7
+ * @version 2.1.8
  * @license Copyright (c) 2015-2020 Meplato GmbH. All rights reserved.
  * @see <a href="https://developer.meplato.com/store2/#terms">Terms of Service</a>
  * @see <a href="https://developer.meplato.com/store2/">External documentation</a>
@@ -41,7 +41,7 @@ public class Service {
     /** API title. */
     public static String TITLE = "Meplato Store API";
     /** API version. */
-    public static String VERSION = "2.1.7";
+    public static String VERSION = "2.1.8";
     /** User Agent. */
     public static String USER_AGENT = "meplato-java-client/2.0";
     /** Default base URL of the API endpoints. */

--- a/src/main/java/com/meplato/store2/products/Product.java
+++ b/src/main/java/com/meplato/store2/products/Product.java
@@ -1467,6 +1467,22 @@ public class Product {
     }
 
     /**
+     * Mode is only used for differential downloads and is the type of change of a
+     * product (CREATED, UPDATED, DELETED).
+     */
+    public String getMode() {
+        return this.mode;
+	}
+
+    /**
+     * Mode is only used for differential downloads and is the type of change of a
+     * product (CREATED, UPDATED, DELETED).
+     */
+    public void setMode(String mode) {
+        this.mode = mode;
+    }
+
+    /**
      * MPN is the manufacturer part number.
      */
     public String getMpn() {

--- a/src/main/java/com/meplato/store2/products/Product.java
+++ b/src/main/java/com/meplato/store2/products/Product.java
@@ -185,6 +185,8 @@ public class Product {
     private double meplatoPrice;
     @SerializedName("merchantId")
     private long merchantId;
+    @SerializedName("mode")
+    private String mode;
     @SerializedName("mpn")
     private String mpn;
     @SerializedName("multiSupplierId")

--- a/src/main/java/com/meplato/store2/products/Service.java
+++ b/src/main/java/com/meplato/store2/products/Service.java
@@ -17,7 +17,7 @@
  *
  * @copyright 2013-2020 Meplato GmbH.
  * @author Meplato API Team <support@meplato.com>
- * @version 2.1.7
+ * @version 2.1.8
  * @license Copyright (c) 2015-2020 Meplato GmbH. All rights reserved.
  * @see <a href="https://developer.meplato.com/store2/#terms">Terms of Service</a>
  * @see <a href="https://developer.meplato.com/store2/">External documentation</a>
@@ -41,7 +41,7 @@ public class Service {
     /** API title. */
     public static String TITLE = "Meplato Store API";
     /** API version. */
-    public static String VERSION = "2.1.7";
+    public static String VERSION = "2.1.8";
     /** User Agent. */
     public static String USER_AGENT = "meplato-java-client/2.0";
     /** Default base URL of the API endpoints. */
@@ -560,6 +560,18 @@ public class Service {
         }
 
         /**
+         * Mode can be used in combination with version to specify if the result should
+         * include all products for the specific version of the catalog (full), or just
+         * the products that changed from the previous version (diff). If the mode is
+         * "diff", the type of change to the product can be found in the attribute
+         * "mode" and has the following values: "Created", "Updated", "Deleted". 
+         */
+        public ScrollService mode(String mode) {
+            this.params.put("mode", mode);
+            return this;
+        }
+
+        /**
          * PageToken must be passed in the 2nd and all consective requests to get the
          * next page of results. You do not need to pass the page token manually. You
          * should just follow the nextUrl link in the metadata to get the next slice of
@@ -583,6 +595,14 @@ public class Service {
         }
 
         /**
+         * Version of the catalog to be retrieved
+         */
+        public ScrollService version(long version) {
+            this.params.put("version", version);
+            return this;
+        }
+
+        /**
          * Execute the operation.
          */
         public ScrollResponse execute() throws ServiceException {
@@ -601,7 +621,7 @@ public class Service {
                 headers.put("Authorization", authorization);
             }
 
-            String uriTemplate = service.getBaseURL() + "/catalogs/{pin}/{area}/products/scroll{?pageToken}";
+            String uriTemplate = service.getBaseURL() + "/catalogs/{pin}/{area}/products/scroll{?pageToken,mode,version}";
             Response response = service.getClient().execute("GET", uriTemplate, params, headers, null);
             if (response != null && response.getStatusCode() >= 200 && response.getStatusCode() < 300) {
                 return response.getBodyJSON(ScrollResponse.class);

--- a/src/test/java/com/meplato/store2/products/ScrollTest.java
+++ b/src/test/java/com/meplato/store2/products/ScrollTest.java
@@ -82,4 +82,32 @@ public class ScrollTest extends BaseTest {
             }
         }
     }
+
+    @Test
+    public void testProductsDifferentialScroll() throws ServiceException, IOException, HttpException {
+        Service service = getProductsService();
+        assertNotNull(service);
+
+        String pageToken = null;
+
+        // Get differential update (from version 2 to 3)
+        this.mockResponseFromFile("products.scroll.differential.success");
+        ScrollResponse response = service.scroll().pin("AD8CCDD5F9").area("live").version(3).mode("diff").execute();
+        assertNotNull(response);
+        assertNotNull(response.getKind());
+        assertNotNull(response.getTotalItems());
+        Product[] products = response.getItems();
+        if (products != null) {
+            for (Product product : products) {
+                assertNotNull(product);
+                assertNotNull(product.getId());
+                assertNotEquals("", product.getId());
+                assertNotNull(product.getSpn());
+                assertNotEquals("", product.getSpn());
+                assertNotEquals("", product.getMode());
+                assertNotNull(product.getCreated());
+                assertNotNull(product.getUpdated());
+            }
+        }
+    }
 }

--- a/src/test/resources/com/meplato/store2/products/products.scroll.differential.success
+++ b/src/test/resources/com/meplato/store2/products/products.scroll.differential.success
@@ -1,0 +1,311 @@
+HTTP/1.1 200 OK
+Cache-Control: private, no-cache
+Content-Type: application/json; charset=utf-8
+Last-Modified: Tue, 31 Mar 2015 14:54:37 GMT
+P3p: CP="This is not a P3P policy!"
+Vary: Cookie
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Ua-Compatible: IE=edge
+X-Xss-Protection: 1; mode=block
+Date: Tue, 31 Mar 2015 14:54:37 GMT
+
+{
+  "kind": "store#products",
+  "selfLink": "https://store2.meplato.com/api/v2/catalogs/AD8CCDD5F9/work/products/scroll?pretty=1\u0026pageToken=c2NhbjsyOzc1OTpFUDU3a3FNelNPdWlzR1dnZFNsTFJBOzc2MDpFUDU3a3FNelNPdWlzR1dnZFNsTFJBOzE7dG90YWxfaGl0czo5ODYyMTs=",
+  "nextLink": "https://store2.meplato.com/api/v2/catalogs/AD8CCDD5F9/work/products/scroll?pageToken=c2NhbjsyOzc1OTpFUDU3a3FNelNPdWlzR1dnZFNsTFJBOzc2MDpFUDU3a3FNelNPdWlzR1dnZFNsTFJBOzE7dG90YWxfaGl0czo5ODYyMTs%3D\u0026pretty=1",
+  "pageToken": "c2NhbjsyOzc1OTpFUDU3a3FNelNPdWlzR1dnZFNsTFJBOzc2MDpFUDU3a3FNelNPdWlzR1dnZFNsTFJBOzE7dG90YWxfaGl0czo5ODYyMTs=",
+  "totalItems": 3,
+  "items": [
+    {
+      "kind": "store#product",
+      "selfLink": "https://store2.meplato.com/api/v2/catalogs/AD8CCDD5F9/work/products/50763599?pretty=1",
+      "id": "50763599@12",
+      "merchantId": 8,
+      "projectId": 1,
+      "catalogId": 12,
+      "spn": "50763599",
+      "name": "Heller BOHRER SORT. IN KASETTE 9TLG. 273824",
+      "description": "Bohrerkassette\n\n 9-teilig, bestehend aus:\nBeton-/Steinbohrer Power 3000\n4/5/6/8 mm\nHSS-G-Super-Stahlbohrer 900\n3/4/5/6/8 mm",
+      "keywords": null,
+      "categories": [],
+      "eclasses": [
+        {
+          "version": "5.1",
+          "code": "21010100"
+        }
+      ],
+      "unspscs": [],
+      "scalePrices": [],
+      "currency": "EUR",
+      "priceQty": 1,
+      "ou": "PK",
+      "cuPerOu": 1,
+      "cu": "PCE",
+      "leadtime": 5,
+      "quantityMin": 1,
+      "quantityMax": null,
+      "quantityInterval": 1,
+      "taxCode": "0.190000",
+      "conditions": null,
+      "gtin": "4010159273824 ",
+      "bpn": "",
+      "mpn": "4010159273824",
+      "manufacturer": "ITW Heller GmbH",
+      "manufactcode": "",
+      "image": "50763599.jpg",
+      "thumbnail": "",
+      "datasheet": "",
+      "safetysheet": "",
+      "hazmats": [
+        {
+          "kind": "Gefahrgut",
+          "text": "NONE"
+        }
+      ],
+      "matgroup": "",
+      "erpGroupSupplier": "",
+      "extSchemaType": "",
+      "extCategoryId": "",
+      "extCategory": "",
+      "custField1": "",
+      "custField2": "",
+      "custField3": "",
+      "custField4": "",
+      "custField5": "",
+      "references": [
+        {
+          "kind": "others",
+          "spn": "505533",
+          "qty": 1
+        },
+        {
+          "kind": "others",
+          "spn": "518929",
+          "qty": 1
+        },
+        {
+          "kind": "others",
+          "spn": "518930",
+          "qty": 1
+        },
+        {
+          "kind": "others",
+          "spn": "518931",
+          "qty": 1
+        },
+        {
+          "kind": "others",
+          "spn": "50539736",
+          "qty": 1
+        },
+        {
+          "kind": "others",
+          "spn": "50539771",
+          "qty": 1
+        },
+        {
+          "kind": "others",
+          "spn": "50581235",
+          "qty": 1
+        },
+        {
+          "kind": "others",
+          "spn": "50765466",
+          "qty": 1
+        }
+      ],
+      "features": [],
+      "availability": {
+        "qty": 0
+      },
+      "messages": [],
+      "tags": null,
+      "imageURL": "https://store2.meplato.com/abc-elektronik/media?file=50763599.jpg\u0026h=230\u0026w=330",
+      "thumbnailURL": "https://store2.meplato.com/abc-elektronik/media?file=50763599.jpg\u0026h=90\u0026w=90",
+      "price": 10.92,
+      "extProductId": "50763599@12",
+      "mode": "Created",
+      "created": "2015-03-20T13:11:02Z",
+      "updated": "2015-03-20T13:11:02Z"
+    },
+    {
+      "kind": "store#product",
+      "selfLink": "https://store2.meplato.com/api/v2/catalogs/AD8CCDD5F9/work/products/50763601?pretty=1",
+      "id": "50763601@12",
+      "merchantId": 8,
+      "projectId": 1,
+      "catalogId": 12,
+      "spn": "50763601",
+      "name": "Heller QUICK-BIT KASS. 5TLG. HOLZ 265690",
+      "description": "QuickBit®-Satz Holz\n\n 5-teilig\n\n Inhalt: 3, 4, 5, 6, 8 mm",
+      "keywords": null,
+      "categories": [],
+      "eclasses": [
+        {
+          "version": "5.1",
+          "code": "21040190"
+        }
+      ],
+      "unspscs": [],
+      "scalePrices": [],
+      "currency": "EUR",
+      "priceQty": 1,
+      "ou": "PK",
+      "cuPerOu": 1,
+      "cu": "PCE",
+      "leadtime": 5,
+      "quantityMin": 1,
+      "quantityMax": null,
+      "quantityInterval": 1,
+      "taxCode": "0.190000",
+      "conditions": null,
+      "gtin": "4010159265690 ",
+      "bpn": "",
+      "mpn": "4010159265690",
+      "manufacturer": "ITW Heller GmbH",
+      "manufactcode": "",
+      "image": "50763601.jpg",
+      "thumbnail": "",
+      "datasheet": "",
+      "safetysheet": "",
+      "hazmats": [
+        {
+          "kind": "Gefahrgut",
+          "text": "NONE"
+        }
+      ],
+      "matgroup": "",
+      "erpGroupSupplier": "",
+      "extSchemaType": "",
+      "extCategoryId": "",
+      "extCategory": "",
+      "custField1": "",
+      "custField2": "",
+      "custField3": "",
+      "custField4": "",
+      "custField5": "",
+      "references": [
+        {
+          "kind": "others",
+          "spn": "505533",
+          "qty": 1
+        },
+        {
+          "kind": "others",
+          "spn": "518929",
+          "qty": 1
+        },
+        {
+          "kind": "others",
+          "spn": "518930",
+          "qty": 1
+        },
+        {
+          "kind": "others",
+          "spn": "518931",
+          "qty": 1
+        },
+        {
+          "kind": "others",
+          "spn": "50539736",
+          "qty": 1
+        },
+        {
+          "kind": "others",
+          "spn": "50539771",
+          "qty": 1
+        },
+        {
+          "kind": "others",
+          "spn": "50581235",
+          "qty": 1
+        },
+        {
+          "kind": "others",
+          "spn": "50765466",
+          "qty": 1
+        }
+      ],
+      "features": [],
+      "availability": {
+        "qty": 0
+      },
+      "messages": [],
+      "tags": null,
+      "imageURL": "https://store2.meplato.com/abc-elektronik/media?file=50763601.jpg\u0026h=230\u0026w=330",
+      "thumbnailURL": "https://store2.meplato.com/abc-elektronik/media?file=50763601.jpg\u0026h=90\u0026w=90",
+      "price": 11.68,
+      "extProductId": "50763601@12",
+      "mode": "Updated",
+      "created": "2015-03-20T13:11:02Z",
+      "updated": "2015-03-20T15:51:32Z"
+    },
+    {
+      "kind": "store#product",
+      "selfLink": "https://store2.meplato.com/api/v2/catalogs/AD8CCDD5F9/work/products/50763603?pretty=1",
+      "id": "50763603@12",
+      "merchantId": 0,
+      "projectId": 0,
+      "catalogId": 0,
+      "spn": "50763603",
+      "name": "",
+      "description": "",
+      "keywords": null,
+      "categories": null,
+      "eclasses": null,
+      "unspscs": null,
+      "currency": "",
+      "country": "",
+      "priceQty": 0,
+      "ou": "",
+      "cuPerOu": 0,
+      "cu": "",
+      "leadtime": null,
+      "quantityMin": null,
+      "quantityMax": null,
+      "quantityInterval": null,
+      "taxCode": "",
+      "taxRate": 0,
+      "conditions": null,
+      "gtin": "",
+      "asin": "",
+      "bpn": "",
+      "mpn": "",
+      "manufacturer": "",
+      "manufactcode": "",
+      "image": "",
+      "thumbnail": "",
+      "datasheet": "",
+      "safetysheet": "",
+      "blobs": null,
+      "hazmats": null,
+      "intrastat": null,
+      "matgroup": "",
+      "erpGroupSupplier": "",
+      "extSchemaType": "",
+      "extCategoryId": "",
+      "extCategory": "",
+      "extProductId": "",
+      "multiSupplierId": "",
+      "multiSupplierName": "",
+      "custField1": "",
+      "custField2": "",
+      "custField3": "",
+      "custField4": "",
+      "custField5": "",
+      "custFields": null,
+      "references": null,
+      "features": null,
+      "availability": null,
+      "messages": null,
+      "tags": null,
+      "excluded": false,
+      "catalogManaged": false,
+      "price": 0,
+      "mode": "Deleted",
+      "created": "0001-01-01T00:00:00Z",
+      "updated": "0001-01-01T00:00:00Z"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds the `version` and `mode` parameters to the `scroll` request. With the new version of the Store API (2.1.8), provided archives are enabled for the merchant, this enables the client to download:
- a full older version of a catalog
- a differential download from version `n-1` to `n` 

Close #13 