### PR TITLE
Ensure ErrorInner.details is not null

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,28 +36,28 @@
 			<dependency>
 				<groupId>junit</groupId>
 				<artifactId>junit</artifactId>
-				<version>4.12</version>
+				<version>4.13.1</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.httpcomponents</groupId>
 				<artifactId>httpclient</artifactId>
-				<version>4.5.7</version>
+				<version>4.5.13</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-io</groupId>
 				<artifactId>commons-io</artifactId>
-				<version>2.6</version>
+				<version>2.8.0</version>
 			</dependency>
 			<dependency>
 				<groupId>com.google.code.gson</groupId>
 				<artifactId>gson</artifactId>
-				<version>2.8.5</version>
+				<version>2.8.6</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-codec</groupId>
 				<artifactId>commons-codec</artifactId>
-				<version>1.11</version>
+				<version>1.15</version>
 			</dependency>
 			<dependency>
 				<groupId>com.damnhandy</groupId>
@@ -67,7 +67,7 @@
 			<dependency>
 				<groupId>joda-time</groupId>
 				<artifactId>joda-time</artifactId>
-				<version>2.10.2</version>
+				<version>2.10.6</version>
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.jetty</groupId>
@@ -125,14 +125,14 @@
 			<extension>
 				<groupId>kr.motd.maven</groupId>
 				<artifactId>os-maven-plugin</artifactId>
-				<version>1.5.0.Final</version>
+				<version>1.6.2</version>
 			</extension>
 		</extensions>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.7.0</version>
+				<version>3.8.1</version>
 				<configuration>
 					<source>1.8</source>
 					<target>1.8</target>

--- a/src/main/java/com/meplato/store2/Error.java
+++ b/src/main/java/com/meplato/store2/Error.java
@@ -15,6 +15,7 @@ package com.meplato.store2;
 
 import com.google.gson.annotations.SerializedName;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -76,7 +77,10 @@ public class Error {
         public ErrorInner(int code, String message, List<String> details) {
             this.code = code;
             this.message = message;
-            this.details = details;
+            if (details != null)
+                this.details = details;
+            else
+                this.details = Collections.emptyList();
         }
 
         /**


### PR DESCRIPTION
This commit makes sure `ErrorInner.getDetails()` will never return
`null` but an empty list. This prevents users from getting an NPE.

We also update dependencies. There is a low severity warning for
versions of junit before 4.13.1.

Close #20